### PR TITLE
Version 2.0.0-alpha

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,4 +1,4 @@
 """
 Just my __init__.py to conform to standards.
 """
-__version__ = "1.2.0-dev"
+__version__ = "2.0.0-alpha"

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,4 +1,4 @@
 """
 Just my __init__.py to conform to standards.
 """
-__version__ = "1.2.0"
+__version__ = "1.2.0-dev"

--- a/components/core.py
+++ b/components/core.py
@@ -15,9 +15,8 @@ the classes used to implement an MVC pattern.
 Usage
   (1) Set the configuration of your game by creating a GameConfig
       instance.
-  (2) Create a GameScreen instance.
-  (3) Create a GameLoopEvents object by passing your GameConfig
-      instance and GameScreen instance.
+  (2) Create a GameScreen instance using the GameConfig created in (1).
+  (3) Create a GameLoopEvents object by passing your GameScreen instance.
   (4) Create a GameLoop object by passing your GameLoopEvents object.
       Call go() .
   (5) Have fun!
@@ -355,18 +354,16 @@ class GameLoopEvents(Subscriber):
             if handler:
                 handler(event)
     
-    def __init__(self, config, game_screen):
+    def __init__(self, game_screen):
         """
         Initializes a GameLoopEvents object. It is important that subclasses
         still initialize GameLoopEvents superclass for the properties config
         and game_screen.
-        
-        @param config
-          A GameConfig instance.
+
         @param game_screen
           A GameScreen instance.
         """
-        self.__config = config
+        self.__config = game_screen.config
         self.__game_screen = game_screen
 
         self.debug_queue = DebugQueue(game_screen)

--- a/components/core.py
+++ b/components/core.py
@@ -214,7 +214,9 @@ class GameScreen(Subscriber):
     # TODO Is this appropriate for a decorator?
     def _is_drawable_clicked(self, drawable, pos):
         """
-        Position is taken as a (width, height) offset.
+        `pos` is taken straight from `pygame.mouse.get_pos()`. Note that it
+        returns coordinates in the form (x, y), which is contrary to the
+        standards of the framework.
         """
         width_limit = drawable.draw_offset[1] + drawable.max_size[0]
         height_limit = drawable.draw_offset[0] + drawable.max_size[1]

--- a/components/core.py
+++ b/components/core.py
@@ -213,6 +213,9 @@ class GameScreen(Subscriber):
 
     # TODO Is this appropriate for a decorator?
     def _is_drawable_clicked(self, drawable, pos):
+        """
+        Position is taken as a (width, height) offset.
+        """
         width_limit = drawable.draw_offset[1] + drawable.max_size[0]
         height_limit = drawable.draw_offset[0] + drawable.max_size[1]
         in_width = drawable.draw_offset[1] <= pos[0] <= width_limit

--- a/components/drawable.py
+++ b/components/drawable.py
@@ -12,7 +12,7 @@ class Drawable(object):
 
     def __init__(self, draw_offset, width_limit=None, height_limit=None):
         """
-        draw_offset is a (width, height) tuple.
+        draw_offset is a (row, col) tuple.
         """
         self.draw_offset = draw_offset if draw_offset else (0, 0)
         # TODO Make the semantics like so: if width_limit is None, make it scale

--- a/components/helpers/grid.py
+++ b/components/helpers/grid.py
@@ -140,7 +140,7 @@ class QuadraticGrid(Grid):
         if dim not in ("width", "height"):
             raise ValueError("dim argument should only be either 'width' or 'height'. Given %s." % dim)
 
-        dimdex = 0 if dim == "width" else 1
+        dimdex = 1 if dim == "width" else 0
         deductibles = self.draw_offset[dimdex]
         max_allowable_area = config.get_config_val("window_size")[dimdex] - deductibles
         if self.max_size[dimdex]:
@@ -170,24 +170,24 @@ class QuadraticGrid(Grid):
             # since we need to draw the end borders too. (Where n is the grid
             # dimension.)
             vborders_limit = len(self.grid[0]) + 1
-            vgrid_pos_limit = (block_height * len(self.grid[0])) + self.draw_offset[1]
+            vgrid_pos_limit = (block_height * len(self.grid[0])) + self.draw_offset[0]
 
             for vborders_offset in xrange(vborders_limit):
-                v_offset = block_width * vborders_offset + self.draw_offset[0]
+                v_offset = block_width * vborders_offset + self.draw_offset[1]
                 pygame.draw.line(
                     window, self.border_properties.color,
-                    (v_offset, self.draw_offset[1]), (v_offset, vgrid_pos_limit),
+                    (v_offset, self.draw_offset[0]), (v_offset, vgrid_pos_limit),
                     self.border_properties.thickness
                 )
 
             hborders_limit = len(self.grid) + 1
-            hgrid_pos_limit = (block_width * len(self.grid)) + self.draw_offset[0]
+            hgrid_pos_limit = (block_width * len(self.grid)) + self.draw_offset[1]
 
             for hborders_offset in xrange(hborders_limit):
-                h_offset = block_height * hborders_offset + self.draw_offset[1]
+                h_offset = block_height * hborders_offset + self.draw_offset[0]
                 pygame.draw.line(
                     window, self.border_properties.color,
-                    (self.draw_offset[0], h_offset), (hgrid_pos_limit, h_offset),
+                    (self.draw_offset[1], h_offset), (hgrid_pos_limit, h_offset),
                     self.border_properties.thickness
                 )
 
@@ -214,8 +214,8 @@ class QuadraticGrid(Grid):
         grid = grid.grid
         rect_list = []
         render_list = []
-        width_offset = offset[0]
-        height_offset = offset[1]
+        width_offset = offset[1]
+        height_offset = offset[0]
 
         for i, row in enumerate(grid):
             for j, col in enumerate(row):
@@ -245,8 +245,8 @@ class QuadraticGrid(Grid):
         """
         block_height = self.__compute_block_dimension(screen.config, "height")
         block_width = self.__compute_block_dimension(screen.config, "width")
-        row_index = int(math.floor((pos[1] - self.draw_offset[1]) / block_height))
-        col_index = int(math.floor((pos[0] - self.draw_offset[0]) / block_width))
+        row_index = int(math.floor((pos[1] - self.draw_offset[0]) / block_height))
+        col_index = int(math.floor((pos[0] - self.draw_offset[1]) / block_width))
 
         if row_index >= len(self.grid) or col_index >= len(self.grid[0]):
             return None

--- a/components/helpers/grid.py
+++ b/components/helpers/grid.py
@@ -140,8 +140,9 @@ class QuadraticGrid(Grid):
         if dim not in ("width", "height"):
             raise ValueError("dim argument should only be either 'width' or 'height'. Given %s." % dim)
 
-        dimdex = 1 if dim == "width" else 0
-        deductibles = self.draw_offset[dimdex]
+        dimdex = 0 if dim == "width" else 1
+        offset_dimdex = 1 if dim == "width" else 0
+        deductibles = self.draw_offset[offset_dimdex]
         max_allowable_area = config.get_config_val("window_size")[dimdex] - deductibles
         if self.max_size[dimdex]:
             max_allowable_area = min(max_allowable_area, self.max_size[dimdex])

--- a/demo/color_blocks/color_blocks_game.py
+++ b/demo/color_blocks/color_blocks_game.py
@@ -105,7 +105,7 @@ class ColorBlocksEvents(GameLoopEvents):
 def main():
     config = GameConfig()
     config.set_config_val("clock_rate", 12)
-    config.set_config_val("window_size", [500, 500 + ColorBlocksScreen.GRID_OFFSET[1]])
+    config.set_config_val("window_size", [500, 500 + ColorBlocksScreen.GRID_OFFSET[0]])
     config.set_config_val("window_title", "Color Blocks Game")
     
     screen = ColorBlocksScreen(config, [10, 10])

--- a/demo/color_blocks/color_blocks_game.py
+++ b/demo/color_blocks/color_blocks_game.py
@@ -73,8 +73,8 @@ class ColorBlocksScreen(GameScreen):
 
 class ColorBlocksEvents(GameLoopEvents):
     
-    def __init__(self, screen, config):
-        super(ColorBlocksEvents, self).__init__(screen, config)
+    def __init__(self, screen):
+        super(ColorBlocksEvents, self).__init__(screen)
         self.key_control = GameLoopEvents.KeyControls()
         self.key_control.register_key(pygame.K_F2, self.__trigger_new_game)
     
@@ -109,7 +109,7 @@ def main():
     config.set_config_val("window_title", "Color Blocks Game")
     
     screen = ColorBlocksScreen(config, [10, 10])
-    loop_events = ColorBlocksEvents(config, screen)
+    loop_events = ColorBlocksEvents(screen)
     return loop_events
 
 if __name__ == "__main__":

--- a/demo/color_blocks/color_blocks_game.py
+++ b/demo/color_blocks/color_blocks_game.py
@@ -21,7 +21,7 @@ class ColorBlocksScreen(GameScreen):
     
     COLOR_MAPPING = (Colors.LUCID_DARK, Colors.HUMAN_RED, Colors.HUMAN_GREEN,
       Colors.HUMAN_BLUE, Colors.LIGHT_GRAY)
-    GRID_OFFSET = (0, 100)
+    GRID_OFFSET = (100, 0)
     
     def __init__(self, config, grid_size):
         """
@@ -40,8 +40,8 @@ class ColorBlocksScreen(GameScreen):
         screen_size = config.get_config_val("window_size")
         self.game_model = self.model
         # Instantiate an underlying grid model
-        self.block_width = int(math.floor((screen_size[0] - ColorBlocksScreen.GRID_OFFSET[0]) / grid_size[0]))
-        self.block_height = int(math.floor((screen_size[1] - ColorBlocksScreen.GRID_OFFSET[1]) / grid_size[1]))
+        self.block_width = int(math.floor((screen_size[0] - ColorBlocksScreen.GRID_OFFSET[1]) / grid_size[0]))
+        self.block_height = int(math.floor((screen_size[1] - ColorBlocksScreen.GRID_OFFSET[0]) / grid_size[1]))
         self.grid_model = QuadraticGrid(
             grid_size[0], grid_size[1],
             draw_offset=ColorBlocksScreen.GRID_OFFSET,
@@ -80,8 +80,9 @@ class ColorBlocksEvents(GameLoopEvents):
     
     def __mouse_click(self, event):
         pos = pygame.mouse.get_pos()
-        row_index = int(math.floor((pos[1] - ColorBlocksScreen.GRID_OFFSET[1]) / self.game_screen.block_height))
-        col_index = int(math.floor(pos[0] / self.game_screen.block_width))
+        row_index, col_index = self.game_screen.grid_model.get_clicked_cell(
+            self.game_screen, pos
+        )
         self.game_screen.game_model.score += self.game_screen.game_model.toggle(row_index, col_index)
         self.game_screen.game_model.falldown()
         self.game_screen.game_model.collapse()

--- a/demo/monster_shooter_demo/monster_shooter_test.py
+++ b/demo/monster_shooter_demo/monster_shooter_test.py
@@ -87,7 +87,7 @@ class PVZMainScreen(GameScreen):
 class PVZEvents(GameLoopEvents):
     
     def __init__(self, config, game_screen):
-        super(PVZEvents, self).__init__(config, game_screen)
+        super(PVZEvents, self).__init__(game_screen)
         self.__meteormon = None
         self.key_controls = GameLoopEvents.KeyControls()
         self.key_controls.register_key(

--- a/demo/snake/game.py
+++ b/demo/snake/game.py
@@ -58,8 +58,8 @@ class SnakeScreen(GameScreen):
 
 class SnakeGameEvents(GameLoopEvents):
     
-    def __init__(self, screen, config):
-        super(SnakeGameEvents, self).__init__(screen, config)
+    def __init__(self, screen):
+        super(SnakeGameEvents, self).__init__(screen)
         self.key_controls = GameLoopEvents.KeyControls()
         self.key_controls.register_key(
             pygame.K_UP,
@@ -115,6 +115,6 @@ if __name__ == "__main__":
     config.set_config_val("difficulty", 1)
 
     screen = SnakeScreen(config, (10, 10))
-    loop_events = SnakeGameEvents(config, screen)
+    loop_events = SnakeGameEvents(screen)
     loop = GameLoop(loop_events)
     loop.go()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_font_paths():
 
 setup(
     name="PyGame Objects",
-    version="1.2.0",
+    version="1.2.0-dev",
     author="Chad Estioco",
     author_email="chadestioco@gmail.com",
     url="https://github.com/skytreader/PyGame-Objects",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_font_paths():
 
 setup(
     name="PyGame Objects",
-    version="1.2.0-dev",
+    version="2.0.0-alpha",
     author="Chad Estioco",
     author_email="chadestioco@gmail.com",
     url="https://github.com/skytreader/PyGame-Objects",

--- a/tests/components/common_ui_tests.py
+++ b/tests/components/common_ui_tests.py
@@ -34,7 +34,7 @@ class ButtonTests(unittest.TestCase):
 
     def test_default_event_handling(self):
         screen = SampleGameScreenUI(GameConfig(), GameModel())
-        loop_events = GameLoopEvents(screen.config, screen)
+        loop_events = GameLoopEvents(screen)
         loop_events.loop_setup()
         loop = GameLoop(loop_events)
         # Python sorcery!

--- a/tests/components/core_tests.py
+++ b/tests/components/core_tests.py
@@ -28,7 +28,7 @@ class ConfigSubscriberMock(Subscriber):
 class LoopEventsMock(GameLoopEvents):
     
     def __init__(self, config, screen):
-        super(LoopEventsMock, self).__init__(config, screen)
+        super(LoopEventsMock, self).__init__(screen)
         self.times_called = 0
     
     def loop_invariant(self):
@@ -43,8 +43,8 @@ class KeyboardHandlingLoopEventsMock(GameLoopEvents):
     are mocked out do not run into each other.
     """
 
-    def __init__(self, config, screen):
-        super(KeyboardHandlingLoopEventsMock, self).__init__(config, screen)
+    def __init__(self, screen):
+        super(KeyboardHandlingLoopEventsMock, self).__init__(screen)
         self.key_controls = GameLoopEvents.KeyControls()
 
     def attach_event_handlers(self):
@@ -175,7 +175,7 @@ class EventHandlerTests(unittest.TestCase):
         Test basic event handling of non-keyboard-based events.
         """
         screen = GameScreen(GameConfig(), GameModel())
-        loop_events = GameLoopEvents(screen.config, screen)
+        loop_events = GameLoopEvents(screen)
         evh1 = EventHandlerMock()
         loop_events.add_event_handler(self.btn_down_event, evh1.handle_event)
         loop = GameLoop(loop_events)
@@ -188,7 +188,7 @@ class EventHandlerTests(unittest.TestCase):
         Test basic event handling of keyboard-based events.
         """
         screen = GameScreen(GameConfig(), GameModel())
-        loop_events = KeyboardHandlingLoopEventsMock(screen.config, screen)
+        loop_events = KeyboardHandlingLoopEventsMock(screen)
         evh1 = EventHandlerMock()
         loop_events.key_controls.register_key(pygame.K_UP, evh1.handle_event)
         loop_events.attach_event_handlers()
@@ -203,7 +203,7 @@ class EventHandlerTests(unittest.TestCase):
        event.
        """
        screen = GameScreen(GameConfig(), GameModel())
-       loop_events = GameLoopEvents(screen.config, screen)
+       loop_events = GameLoopEvents(screen)
        evh1 = EventHandlerMock()
        evh2 = EventHandlerMock()
        loop_events.add_event_handler(self.btn_down_event, evh1.handle_event)

--- a/tests/components/core_tests.py
+++ b/tests/components/core_tests.py
@@ -1,4 +1,5 @@
 from components.core import DebugQueue, GameConfig, GameModel, GameScreen, GameLoop, GameLoopEvents
+from components.drawable import Drawable
 from components.subscriber_pattern import Subscriber
 from mock import patch
 from StringIO import StringIO
@@ -136,6 +137,12 @@ class GameScreenTest(unittest.TestCase):
             (window_size_debug[0], window_size_debug[1] + GameScreen.DEBUG_SPACE_PROVISIONS),
             screen_debug.screen_size
         )
+
+    def test_is_drawable_clicked_happy(self):
+        sample_drawable = Drawable((0, 0), 100, 88)
+        cfg = GameConfig(window_size=(200, 160))
+        screen = GameScreen(cfg, GameModel())
+        self.assertTrue(screen._is_drawable_clicked(sample_drawable, (90, 44)))
 
 class DebugQueueTest(unittest.TestCase):
     

--- a/tests/components/helpers/grid_tests.py
+++ b/tests/components/helpers/grid_tests.py
@@ -136,11 +136,15 @@ class QuadraticGridTests(unittest.TestCase):
         self.assertTrue(draw_rect.called)
 
         block_dim = 50
+        # Python sorcery
+        self.assertEqual(block_dim, qg._QuadraticGrid__compute_block_dimension(config, "width"))
+        self.assertEqual(block_dim, qg._QuadraticGrid__compute_block_dimension(config, "height"))
+        window_dimensions = config.get_config_val("window_size")
         # The horizontal borders
         for i in range(10):
-            y = i * block_dim + draw_offset[1]
+            y = i * block_dim + draw_offset[0]
             draw_line.assert_any_call(
-                window, border_prop.color, (0, y), (500, y),
+                window, border_prop.color, (0, y), (window_dimensions[0], y),
                 border_prop.thickness
             )
 
@@ -148,7 +152,7 @@ class QuadraticGridTests(unittest.TestCase):
         for i in range(10):
             x = i * block_dim
             draw_line.assert_any_call(
-                window, border_prop.color, (x, draw_offset[1]), (x, 600),
+                window, border_prop.color, (x, draw_offset[0]), (x, window_dimensions[1]),
                 border_prop.thickness
             )
 

--- a/tests/components/helpers/grid_tests.py
+++ b/tests/components/helpers/grid_tests.py
@@ -130,7 +130,7 @@ class QuadraticGridTests(unittest.TestCase):
         game_screen = GameScreen(config, GameModel())
         window = pygame.display.set_mode(config.get_config_val("window_size"))
         border_prop = BorderProperties()
-        draw_offset = (0, 100)
+        draw_offset = (100, 0)
         qg = QuadraticGrid(10, 10, draw_offset=draw_offset, border_properties=border_prop)
         qg.draw(window, game_screen)
         self.assertTrue(draw_rect.called)

--- a/tests/snake/game_tests.py
+++ b/tests/snake/game_tests.py
@@ -21,7 +21,7 @@ class GameTests(unittest.TestCase):
         config.set_config_val("log_to_terminal", True)
         config.set_config_val("difficulty", 1)
         screen = SnakeScreen(config, (10, 10))
-        loop_events = SnakeGameEvents(config, screen)
+        loop_events = SnakeGameEvents(screen)
         loop = GameLoop(loop_events, is_test=True)
         loop.go()
 


### PR DESCRIPTION
Added "-alpha" signifier since plain version numbers are now insufficient to determine the state of this library.

Backwards-compatibility-breaking changes introduced are...

- Change convention for `draw_offset` from being (width, height) to (row, col) because it makes more sense.
- Change constructor of `GameLoopEvents` so that it no longer needs a `GameConfig` object.